### PR TITLE
Fix SAF persistable permission handling and validate selected files

### DIFF
--- a/app/src/main/java/com/example/vocalremover/MainActivity.kt
+++ b/app/src/main/java/com/example/vocalremover/MainActivity.kt
@@ -34,14 +34,19 @@ class MainActivity : AppCompatActivity() {
     private val workManager by lazy { WorkManager.getInstance(this) }
 
     private val filePicker =
-        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val data = result.data
+            val uri = data?.data
             if (uri != null) {
-                Log.i(TAG, "Picked uri=$uri")
+                val flags = data.flags
+                Log.i(TAG, "Picked uri=$uri with flags=0x${flags.toString(16)}")
                 viewModel.updateSelection(uri, resolveFileName(uri))
                 lifecycleScope.launch {
-                    persistUriPermission(uri)
+                    persistUriPermission(uri, flags)
                     validateUriAccess(uri)
                 }
+            } else {
+                Log.w(TAG, "File picker returned null uri")
             }
         }
 
@@ -69,7 +74,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupListeners() {
-        binding.selectFileButton.setOnClickListener { filePicker.launch(arrayOf("audio/*")) }
+        binding.selectFileButton.setOnClickListener { filePicker.launch(buildOpenDocumentIntent()) }
         binding.startProcessingButton.setOnClickListener { startProcessing() }
         binding.cancelProcessingButton.setOnClickListener {
             workManager.cancelUniqueWork(AudioProcessWorker.WORK_NAME)
@@ -193,11 +198,37 @@ class MainActivity : AppCompatActivity() {
         return uri.lastPathSegment ?: "audio_file"
     }
 
-    private fun persistUriPermission(uri: Uri) {
-        val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
-        Log.i(TAG, "Requesting persistable permission for $uri with flags=0x${flags.toString(16)}")
+    private fun buildOpenDocumentIntent(): Intent {
+        return Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "audio/*"
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+        }
+    }
+
+    private fun persistUriPermission(uri: Uri, resultFlags: Int) {
+        val hasPersistable =
+            resultFlags and Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION != 0
+        val takeFlags = resultFlags and
+            (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+
+        if (!hasPersistable) {
+            Log.w(TAG, "Persistable permission not granted for $uri, skipping persist")
+            return
+        }
+
+        if (takeFlags == 0) {
+            Log.w(TAG, "No read/write flags granted for $uri, skipping persist")
+            return
+        }
+
+        Log.i(
+            TAG,
+            "Requesting persistable permission for $uri with flags=0x${takeFlags.toString(16)}"
+        )
         try {
-            contentResolver.takePersistableUriPermission(uri, flags)
+            contentResolver.takePersistableUriPermission(uri, takeFlags)
         } catch (e: SecurityException) {
             Log.w(TAG, "Unable to persist permission for $uri", e)
         } catch (e: IllegalArgumentException) {
@@ -209,6 +240,18 @@ class MainActivity : AppCompatActivity() {
         withContext(Dispatchers.IO) {
             val type = runCatching { contentResolver.getType(uri) }.getOrNull()
             Log.i(TAG, "Content type for $uri = ${type ?: "unknown"}")
+            if (type != null && !type.startsWith("audio/")) {
+                Log.w(TAG, "Selected file is not audio: $type")
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Выбранный файл не является аудио",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    viewModel.setError("Выбранный файл не является аудио")
+                }
+                return@withContext
+            }
 
             val readAttempt = runCatching {
                 contentResolver.openInputStream(uri)?.use { input ->
@@ -219,6 +262,14 @@ class MainActivity : AppCompatActivity() {
 
             readAttempt.onSuccess { bytesRead ->
                 Log.i(TAG, "Validated stream for $uri, bytesRead=$bytesRead")
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Файл открыт: ${viewModel.uiState.value.selectedName}",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    viewModel.setStatus("Файл открыт")
+                }
             }.onFailure { error ->
                 Log.w(TAG, "Failed to open stream for $uri", error)
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/example/vocalremover/ProcessingViewModel.kt
+++ b/app/src/main/java/com/example/vocalremover/ProcessingViewModel.kt
@@ -124,6 +124,10 @@ class ProcessingViewModel : ViewModel() {
         }
     }
 
+    fun setStatus(message: String) {
+        _uiState.update { it.copy(statusMessage = message, errorMessage = null) }
+    }
+
     fun clearResult() {
         _uiState.update {
             it.copy(


### PR DESCRIPTION
### Motivation

- Prevent crashes on file selection caused by passing incorrect persist flags to `takePersistableUriPermission` when using SAF.
- Ensure the app only attempts to persist read/write permissions that were actually granted by the picker intent.
- Provide immediate user feedback and state updates after a file is opened so the user flow is not broken by silent failures.
- Validate that the selected document is audio before attempting to process it.

### Description

- Replace `ActivityResultContracts.OpenDocument()` with `StartActivityForResult()` to capture intent flags and launch `ACTION_OPEN_DOCUMENT` via a new `buildOpenDocumentIntent()` that adds `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_PERSISTABLE_URI_PERMISSION`.
- Implement `persistUriPermission(uri, resultFlags)` which checks for `FLAG_GRANT_PERSISTABLE_URI_PERMISSION` and only passes `FLAG_GRANT_READ_URI_PERMISSION`/`FLAG_GRANT_WRITE_URI_PERMISSION` bits to `contentResolver.takePersistableUriPermission`, while catching `SecurityException` and `IllegalArgumentException`.
- Add MIME validation in `validateUriAccess` to ensure the selected file `type` starts with `audio/`, show a toast and set an error via the ViewModel if not audio, and show success toast + update status via new `viewModel.setStatus` when validation succeeds.
- Add `setStatus` helper to `ProcessingViewModel` to allow updating `statusMessage` without setting an error.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69608896d6608332b36ebf0ff8a4287e)