### PR TITLE
Enable FULL FFmpeg offline processing with fallback and safer URI handling

### DIFF
--- a/app/src/main/java/com/example/vocalremover/FeatureFlags.kt
+++ b/app/src/main/java/com/example/vocalremover/FeatureFlags.kt
@@ -1,0 +1,21 @@
+package com.example.vocalremover
+
+import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.ReturnCode
+
+object FeatureFlags {
+    val isFfmpegAvailable: Boolean by lazy {
+        val classAvailable = runCatching {
+            Class.forName("com.arthenica.ffmpegkit.FFmpegKit")
+        }.isSuccess
+
+        if (!classAvailable) {
+            return@lazy false
+        }
+
+        runCatching {
+            val session = FFmpegKit.execute("-version")
+            ReturnCode.isSuccess(session.returnCode)
+        }.getOrDefault(false)
+    }
+}

--- a/app/src/main/java/com/example/vocalremover/SilenceDetectParser.kt
+++ b/app/src/main/java/com/example/vocalremover/SilenceDetectParser.kt
@@ -1,0 +1,45 @@
+package com.example.vocalremover
+
+data class SilenceInterval(val start: Double, val end: Double)
+
+object SilenceDetectParser {
+    fun parse(logs: String): List<SilenceInterval> {
+        val intervals = mutableListOf<SilenceInterval>()
+        var currentStart: Double? = null
+
+        logs.lineSequence().forEach { line ->
+            when {
+                line.contains("silence_start") -> {
+                    val start = line.substringAfter("silence_start:")
+                        .substringBefore(" ")
+                        .trim()
+                        .toDoubleOrNull()
+                    if (start != null) {
+                        if (currentStart != null && currentStart != start) {
+                            intervals.add(SilenceInterval(currentStart ?: 0.0, start))
+                        }
+                        currentStart = start
+                    }
+                }
+
+                line.contains("silence_end") -> {
+                    val end = line.substringAfter("silence_end:")
+                        .substringBefore(" ")
+                        .trim()
+                        .toDoubleOrNull()
+                    if (end != null) {
+                        val start = currentStart ?: 0.0
+                        intervals.add(SilenceInterval(start, end))
+                    }
+                    currentStart = null
+                }
+            }
+        }
+
+        if (currentStart != null) {
+            intervals.add(SilenceInterval(currentStart ?: 0.0, Double.POSITIVE_INFINITY))
+        }
+
+        return intervals.sortedBy { it.start }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://maven.arthenica.com") }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Replace the previous simplified output-only flow with a full, offline FFmpeg-based processing path that performs conversion, silence analysis and segment slicing.
- Provide a centralized runtime feature flag so the app can choose FULL processing when FFmpeg is present and fall back to the simplified ZIP behaviour when it is not.
- Avoid URI permission crashes by switching to `OpenDocument` and using a constrained `takePersistableUriPermission` call.
- Ensure FFmpegKit can be resolved during builds by adding Arthenica's Maven repository.

### Description
- Added `FeatureFlags` (`FeatureFlags.kt`) which detects presence and basic functionality of FFmpeg by loading `com.arthenica.ffmpegkit.FFmpegKit` and executing `-version`.
- Added `SilenceDetectParser` (`SilenceDetectParser.kt`) to extract `silence_start`/`silence_end` intervals from FFmpeg logs.
- Reworked `AudioProcessWorker` to copy the input (with metadata) into cache, probe `FeatureFlags`, and run a FULL pipeline when available that: converts to WAV, applies bandpass enhancement, runs `silencedetect`, uses `FFprobe` to read duration, computes voice segments, slices segments via FFmpeg, zips segments plus `info.txt`/`log.txt`, and saves the ZIP to Downloads; when FFmpeg is unavailable the worker falls back to a simplified ZIP of the original with an updated `info.txt`.
- Updated `MainActivity` to use `ActivityResultContracts.OpenDocument()` and simplified `persistUriPermission(uri)` to request only `Intent.FLAG_GRANT_READ_URI_PERMISSION` to avoid invalid flag errors.
- Updated `settings.gradle.kts` to include `maven { url = uri("https://maven.arthenica.com") }` so FFmpegKit artifacts can be resolved.
- Misc: improved path quoting for FFmpeg commands, added info/log writing into ZIP, and safer duration probing via `FFprobeKit.execute`.

### Testing
- No automated tests were executed on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f1f5f7d88332b6aabb8231cdf603)